### PR TITLE
Update boost.mk

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_73_0
-$(package)_download_path=https://downloads.sourceforge.net/project/boost/boost/1.73.0/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
 $(package)_dependencies=libiconv


### PR DESCRIPTION
Link to archive is broken.
change from:
packages/boost.mk:$(package)_download_path=https://downloads.sourceforge.net/project/boost/boost/1.73.0/
to:
packages/boost.mk:$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/